### PR TITLE
Render configured interface names safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.1 - 2026-08-20
+
+- Render configuration-derived network interface names as plain text
+- Escape interface-name markup before passing it to the shared bar tooltip
+
 ## 1.0.0 - 2026-08-20
 
 Initial public release.

--- a/Metrics.js
+++ b/Metrics.js
@@ -7,6 +7,18 @@ function clamp(value, minimum, maximum) {
   return Math.max(minimum, Math.min(maximum, value))
 }
 
+// WidgetButton forwards tooltip strings to the shell's shared Text item,
+// which currently uses Qt's automatic rich-text detection. Escape markup at
+// that boundary so configuration-derived labels cannot become HTML there.
+function escapeMarkup(value) {
+  return String(value === undefined || value === null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
 function parseCpu(raw, previous) {
   var lines = String(raw || "").split("\n")
   var snapshots = ({})
@@ -188,6 +200,7 @@ if (typeof module !== "undefined" && module.exports) {
     parseDiscovery: parseDiscovery,
     parseFilesystem: parseFilesystem,
     peakValue: peakValue,
-    maximumPercent: maximumPercent
+    maximumPercent: maximumPercent,
+    escapeMarkup: escapeMarkup
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import "Metrics.js" as Model
 
 Panel {
   id: root
@@ -178,9 +179,12 @@ Panel {
   }
 
   function tooltipText() {
+    // WidgetButton's shared tooltip only accepts a string and renders it with
+    // Text.AutoText, so neutralize markup before handing it configuration.
+    var interfaceName = Model.escapeMarkup(metrics.activeInterface)
     return [
       "CPU " + percent(metrics.cpuPercent) + " · RAM " + percent(metrics.memoryPercent) + " · " + temperatureText(),
-      "Load " + loadText() + (metrics.activeInterface !== "" ? " · " + metrics.activeInterface : ""),
+      "Load " + loadText() + (interfaceName !== "" ? " · " + interfaceName : ""),
       "Net ↓ " + formatRate(metrics.networkDownBps) + " ↑ " + formatRate(metrics.networkUpBps),
       "Disk R " + formatRate(metrics.diskReadBps) + " · W " + formatRate(metrics.diskWriteBps),
       "Right-click cycles display · Middle-click opens btop"
@@ -622,6 +626,7 @@ Panel {
     PanelSectionHeader {
       id: headingText
       text: title
+      textFormat: Text.PlainText
       foreground: root.foreground
       fontFamily: root.fontFamily
       elide: Text.ElideRight

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "harshith.system-monitor",
   "name": "System Monitor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Harshith",
   "license": "MIT",
   "homepage": "https://github.com/Harshith292002/omarchy-system-monitor",

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -50,6 +50,19 @@ test("network parser follows the selected interface counters", () => {
   assert.equal(Model.parseDefaultInterface("Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\nwlan0\t00000000\t0101A8C0\t0003\t0\t0\t600\t00000000\t0\t0\t0\n"), "wlan0")
 })
 
+test("configuration-derived labels cannot become rich text", () => {
+  const crafted = "<img src=\"https://example.invalid/pixel?x=1&y='2'\">"
+  assert.equal(
+    Model.escapeMarkup(crafted),
+    "&lt;img src=&quot;https://example.invalid/pixel?x=1&amp;y=&#39;2&#39;&quot;&gt;"
+  )
+
+  const qml = fs.readFileSync(path.join(root, "Panel.qml"), "utf8")
+  assert.match(qml, /Model\.escapeMarkup\(metrics\.activeInterface\)/)
+  assert.match(qml, /id: headingText[\s\S]{0,160}textFormat: Text\.PlainText/)
+  assert.doesNotMatch(qml, /" · " \+ metrics\.activeInterface/)
+})
+
 test("discovery parser maps sensor probe output into runtime paths", () => {
   const raw = [
     "cpu_temp\t/sys/class/hwmon/hwmon2/temp1_input",
@@ -66,7 +79,7 @@ test("manifest describes a public bar widget with configurable thresholds", () =
   const manifest = JSON.parse(fs.readFileSync(path.join(root, "manifest.json"), "utf8"))
   assert.equal(manifest.schemaVersion, 1)
   assert.equal(manifest.id, "harshith.system-monitor")
-  assert.equal(manifest.version, "1.0.0")
+  assert.equal(manifest.version, "1.0.1")
   assert.equal(manifest.license, "MIT")
   assert.equal(manifest.homepage, "https://github.com/Harshith292002/omarchy-system-monitor")
   assert.equal(manifest.barWidget.defaultSection, "right")


### PR DESCRIPTION
## Summary
- render the network section heading with Text.PlainText
- escape configuration-derived interface names before the shared tooltip receives them
- add a crafted img-tag regression case and release the fix as 1.0.1

## Validation
- node --test tests/model.test.js
- omarchy plugin validate .
- jq empty manifest.json

Marketplace follow-up: HANCORE-linux/omarchy-plugin-marketplace#1095