### PR TITLE
Fix GPU temperature discovery on the xe driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.1 - 2026-08-26
+
+- Fix GPU temperature discovery on the `xe` driver (Intel Arc, Meteor Lake,
+  Lunar Lake and newer): its hwmon package sensor is `temp2_input`, not
+  `temp1_input`, so those cards previously reported no temperature at all
+- Document that NVIDIA's proprietary driver exposes no sysfs data whatsoever,
+  not even temperature, and is unsupported by design rather than by omission
+
 ## 1.0.1 - 2026-08-20
 
 - Render configuration-derived network interface names as plain text

--- a/README.md
+++ b/README.md
@@ -77,17 +77,20 @@ subsets:
 
 | Driver | Utilization | Temperature | VRAM |
 | --- | --- | --- | --- |
-| `amdgpu` | yes | yes | yes |
-| `i915` / `xe` (Intel, including Arc) | no | yes | no |
-| `nouveau` | no | yes | no |
+| `amdgpu` | yes | yes (`temp1_input`) | yes |
+| `i915` (Intel, pre-Arc) | no | yes, kernel 6.12+ (`temp1_input`) | no |
+| `xe` (Intel, Arc/Meteor Lake/Lunar Lake+) | no | yes, kernel 6.15+ (`temp2_input` — `xe` has no `temp1`) | no |
+| `nouveau` | no | yes (`temp1_input`) | no |
 | NVIDIA proprietary | no | no | no |
 
 Only `amdgpu` publishes a device-wide utilization counter in sysfs. Intel
 exposes utilization through the PMU or per-client `fdinfo`, both of which need
-either elevated capabilities or per-process accounting, and the NVIDIA
-proprietary driver requires NVML. Reading those would mean spawning a helper
-process on every sample, which this plugin deliberately avoids, so a card that
-cannot be read is left out rather than reported as idle.
+either elevated capabilities or per-process accounting. The NVIDIA proprietary
+driver doesn't register a `hwmon` device at all — not even for temperature —
+so every reading, utilization included, requires NVML (`nvidia-smi`). Reading
+any of these would mean spawning a helper process on every sample, which this
+plugin deliberately avoids, so a card that cannot be read is left out rather
+than reported as idle, and NVIDIA is unsupported outright.
 
 A card with a temperature sensor but no utilization counter still gets a
 section, showing just the tiles it can fill. When nothing is readable, the

--- a/discover-sensors.sh
+++ b/discover-sensors.sh
@@ -42,11 +42,18 @@ done
 # GPU. Vendors expose different subsets, so each sensor is probed on its own
 # rather than gated behind one capability:
 #
-#   amdgpu        gpu_busy_percent, hwmon temperature, mem_info_vram_*
-#   i915 / xe     hwmon temperature only; no device-wide busy counter exists
-#                 in sysfs, utilisation needs the PMU or per-client fdinfo
-#   nouveau       hwmon temperature only
-#   NVIDIA prop.  nothing readable without NVML
+#   amdgpu        gpu_busy_percent, hwmon temperature (temp1_input), mem_info_vram_*
+#   i915          hwmon temperature only (temp1_input); no device-wide busy
+#                 counter exists in sysfs, utilisation needs the PMU or
+#                 per-client fdinfo
+#   xe            hwmon temperature only, but as temp2_input: xe's hwmon ABI
+#                 numbers package temp starting at 2, there is no temp1 (see
+#                 Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon)
+#   nouveau       hwmon temperature only (temp1_input)
+#   NVIDIA prop.  nothing readable via sysfs at all, not even temperature —
+#                 every reading requires NVML (nvidia-smi), which means a
+#                 helper process. Deliberately left unsupported rather than
+#                 spawning one per sample.
 #
 # Cards are ranked so one publishing utilisation wins outright, then by video
 # memory. That keeps the discrete adapter on hybrid systems without hardcoding
@@ -71,10 +78,18 @@ for card in "$drm_root"/card*; do
   busy=""
   [[ -r "$device/gpu_busy_percent" ]] && busy="$device/gpu_busy_percent"
 
+  # temp1_input covers amdgpu, i915, and nouveau. xe has no temp1 at all —
+  # its package sensor starts numbering at temp2 — so that is checked as a
+  # fallback rather than a replacement.
   temp=""
   for hwmon in "$device"/hwmon/hwmon*; do
-    [[ -r "$hwmon/temp1_input" ]] || continue
-    temp="$hwmon/temp1_input"
+    if [[ -r "$hwmon/temp1_input" ]]; then
+      temp="$hwmon/temp1_input"
+    elif [[ -r "$hwmon/temp2_input" ]]; then
+      temp="$hwmon/temp2_input"
+    else
+      continue
+    fi
     break
   done
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "harshith.system-monitor",
   "name": "System Monitor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Harshith",
   "license": "MIT",
   "homepage": "https://github.com/Harshith292002/omarchy-system-monitor",

--- a/tests/discovery.test.sh
+++ b/tests/discovery.test.sh
@@ -53,6 +53,18 @@ check "intel" intel gpu_busy EMPTY
 check "intel" intel gpu_temp "card"
 check "intel" intel gpu_vram_total EMPTY
 
+echo "Intel xe (package temp is temp2_input, there is no temp1) - still found"
+mkdir -p "$work/xe/card0/device/hwmon/hwmon0"
+printf '48000\n' >"$work/xe/card0/device/hwmon/hwmon0/temp2_input"
+check "xe" xe gpu_busy EMPTY
+check "xe" xe gpu_temp "temp2_input"
+
+echo "Card with both temp1 and temp2 - temp1 wins (amdgpu edge sensor over the rest)"
+mkdir -p "$work/temp-precedence/card0/device/hwmon/hwmon0"
+printf '30000\n' >"$work/temp-precedence/card0/device/hwmon/hwmon0/temp1_input"
+printf '55000\n' >"$work/temp-precedence/card0/device/hwmon/hwmon0/temp2_input"
+check "temp-precedence" temp-precedence gpu_temp "temp1_input"
+
 echo "NVIDIA proprietary (nothing readable) - reports nothing at all"
 card nvidia card0 "" "" ""
 check "nvidia" nvidia gpu_busy EMPTY

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -117,7 +117,7 @@ test("manifest describes a public bar widget with configurable thresholds", () =
   const manifest = JSON.parse(fs.readFileSync(path.join(root, "manifest.json"), "utf8"))
   assert.equal(manifest.schemaVersion, 1)
   assert.equal(manifest.id, "harshith.system-monitor")
-  assert.equal(manifest.version, "1.1.0")
+  assert.equal(manifest.version, "1.1.1")
   assert.equal(manifest.license, "MIT")
   assert.equal(manifest.homepage, "https://github.com/Harshith292002/omarchy-system-monitor")
   assert.equal(manifest.barWidget.defaultSection, "right")


### PR DESCRIPTION
## What

PR #4 added GPU discovery, but only checks `hwmon/*/temp1_input` for a
card's temperature sensor. Intel's `xe` driver (Arc, Meteor Lake, Lunar
Lake and newer) numbers its package-temperature sensor starting at
`temp2_input` — there is no `temp1` on that driver at all
([`sysfs-driver-intel-xe-hwmon`](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon)).
So `xe` cards were silently left with no GPU temperature reading, even
on kernels new enough to expose one (6.15+).

Confirmed while looking into "which other GPUs can this plugin actually
support" — the honest answer, backed by kernel ABI docs and driver
source: only `amdgpu` publishes device-wide utilization or VRAM via
sysfs. `i915`/`xe`/`nouveau` can offer temperature only, and NVIDIA's
proprietary driver registers no `hwmon` device at all, so it can't gain
even a temperature reading without spawning `nvidia-smi`/NVML — which
this plugin deliberately avoids. That's now spelled out in the README's
vendor table instead of just implied.

## Fix

`temp2_input` is checked as a fallback only when `temp1_input` is
absent, so `amdgpu`, `i915`, and `nouveau` (all `temp1_input`) are
unaffected — verified by a new fixture test that both cards are present
and `temp1` still wins.

## Changes

| File | Change |
| --- | --- |
| `discover-sensors.sh` | `temp2_input` fallback for the `xe` driver |
| `tests/discovery.test.sh` | fixtures for temp2-only and temp1-over-temp2 precedence |
| `README.md` | vendor table split by driver, sensor filename, and minimum kernel; clarifies why NVIDIA is unsupported |
| `CHANGELOG.md` | 1.1.1 entry |
| `manifest.json`, `tests/model.test.js` | version bump to 1.1.1 |

## Testing

- `node --test tests/model.test.js` — 12/12 passing
- `bash tests/discovery.test.sh` — all fixtures passing, including the two new ones
- `omarchy-plugin-validate .` — exits 0
- Ran against this machine's real sysfs tree (Intel Ice Lake `i915`, no hwmon exposed on this generation) — confirms no regression, GPU section still correctly stays hidden rather than showing stale/wrong data

🤖 Generated with [Claude Code](https://claude.com/claude-code)