### PR TITLE
Document the GPU bar mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ omarchy restart shell
 | Action | Result |
 | --- | --- |
 | Left-click | Open or close the dashboard |
-| Right-click | Cycle `Adaptive` → `CPU` → `Memory` → `Both` |
+| Right-click | Cycle `Adaptive` → `CPU` → `Memory` → `Both` (`GPU` is added to the cycle automatically when a card publishes a utilization counter) |
 | Middle-click | Open `btop` |
 | `R` while open | Refresh metrics now |
 | `B` while open | Open `btop` |
@@ -108,7 +108,7 @@ Open **Setup → Plugins → System Monitor** to change these values:
 
 | Setting | Default | Range or behavior |
 | --- | ---: | --- |
-| Bar display | Adaptive | `Adaptive`, `CPU`, `Memory`, or `Both` |
+| Bar display | Adaptive | `Adaptive`, `CPU`, `Memory`, `GPU`, or `Both` |
 | Closed refresh | 5 s | 2–60 seconds |
 | Open refresh | 2 s | 1–10 seconds |
 | Warning threshold | 80% | 50–95% |


### PR DESCRIPTION
## What

PR #4 added a `GPU` bar-display option (added to the cycle automatically
when a card publishes a utilization counter), but the README's **Use**
and **Configure** sections still only listed `Adaptive`/`CPU`/`Memory`/`Both`.

## Testing

- `node --test tests/model.test.js` — 12/12 passing
- `bash tests/discovery.test.sh` — all fixtures passing
- `omarchy-plugin-validate .` — exits 0
- `git diff --check`, `jq empty manifest.json` — clean

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)