### PR TITLE
Add an Icon bar display mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.0 - 2026-08-29
+
+- Add an `Icon` bar display mode: the plugin glyph alone, no live text, for
+  bars that should stay quiet. It still tints at warning/critical pressure and
+  keeps the tooltip and dashboard; right-click cycling includes it
+
 ## 1.1.1 - 2026-08-26
 
 - Fix GPU temperature discovery on the `xe` driver (Intel Arc, Meteor Lake,

--- a/Panel.qml
+++ b/Panel.qml
@@ -29,6 +29,9 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
   readonly property string barMode: String(setting("barMode", "Adaptive"))
+  // Icon mode keeps the bar quiet: the plugin glyph alone, still tinted at
+  // warning/critical pressure, tooltip and dashboard unchanged.
+  readonly property bool iconOnly: barMode === "Icon"
   readonly property real warningThreshold: Math.min(Number(setting("warningPercent", 80)), criticalThreshold - 1)
   readonly property real criticalThreshold: Math.max(Number(setting("criticalPercent", 95)), 61)
   readonly property real pressure: Math.max(metrics.cpuPercent, metrics.memoryPercent)
@@ -249,7 +252,7 @@ Panel {
   }
 
   function cycleBarMode() {
-    var modes = hasGpuUsage ? ["Adaptive", "CPU", "Memory", "GPU", "Both"] : ["Adaptive", "CPU", "Memory", "Both"]
+    var modes = hasGpuUsage ? ["Adaptive", "CPU", "Memory", "GPU", "Both", "Icon"] : ["Adaptive", "CPU", "Memory", "Both", "Icon"]
     var index = modes.indexOf(barMode)
     var next = modes[(index + 1) % modes.length]
     settings = Object.assign({}, settings, { barMode: next })
@@ -314,9 +317,16 @@ Panel {
     function refresh(): string { metrics.sample(); return "ok" }
   }
 
+  function barPressed(buttonCode) {
+    if (buttonCode === Qt.RightButton) cycleBarMode()
+    else if (buttonCode === Qt.MiddleButton) launchBtop()
+    else toggle()
+  }
+
   WidgetButton {
     id: button
     anchors.fill: parent
+    visible: !root.iconOnly
     bar: root.bar
     text: root.barLabel()
     fontSize: Style.font.caption
@@ -324,16 +334,24 @@ Panel {
     active: root.warning || root.critical
     activeColor: root.critical ? root.urgent : root.warningColor
     tooltipText: root.tooltipText()
-    onPressed: function(buttonCode) {
-      if (buttonCode === Qt.RightButton) root.cycleBarMode()
-      else if (buttonCode === Qt.MiddleButton) root.launchBtop()
-      else root.toggle()
-    }
+    onPressed: function(buttonCode) { root.barPressed(buttonCode) }
+  }
+
+  BarIconButton {
+    id: iconButton
+    anchors.fill: parent
+    visible: root.iconOnly
+    bar: root.bar
+    text: root.heroGlyph
+    active: root.warning || root.critical
+    activeColor: root.critical ? root.urgent : root.warningColor
+    tooltipText: root.tooltipText()
+    onPressed: function(buttonCode) { root.barPressed(buttonCode) }
   }
 
   KeyboardPanel {
     id: panel
-    anchorItem: button
+    anchorItem: root.iconOnly ? iconButton : button
     owner: root
     bar: root.bar
     open: root.opened

--- a/Panel.qml
+++ b/Panel.qml
@@ -289,8 +289,8 @@ Panel {
   }
 
   visible: true
-  implicitWidth: button.implicitWidth
-  implicitHeight: button.implicitHeight
+  implicitWidth: iconOnly ? iconButton.implicitWidth : button.implicitWidth
+  implicitHeight: iconOnly ? iconButton.implicitHeight : button.implicitHeight
 
   onOpenedChanged: {
     if (opened) {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ omarchy restart shell
 | Action | Result |
 | --- | --- |
 | Left-click | Open or close the dashboard |
-| Right-click | Cycle `Adaptive` → `CPU` → `Memory` → `Both` (`GPU` is added to the cycle automatically when a card publishes a utilization counter) |
+| Right-click | Cycle `Adaptive` → `CPU` → `Memory` → `Both` → `Icon` (`GPU` is added to the cycle automatically when a card publishes a utilization counter) |
 | Middle-click | Open `btop` |
 | `R` while open | Refresh metrics now |
 | `B` while open | Open `btop` |
@@ -108,7 +108,7 @@ Open **Setup → Plugins → System Monitor** to change these values:
 
 | Setting | Default | Range or behavior |
 | --- | ---: | --- |
-| Bar display | Adaptive | `Adaptive`, `CPU`, `Memory`, `GPU`, or `Both` |
+| Bar display | Adaptive | `Adaptive`, `CPU`, `Memory`, `GPU`, `Both`, or `Icon` (glyph only; still tints at warning/critical) |
 | Closed refresh | 5 s | 2–60 seconds |
 | Open refresh | 2 s | 1–10 seconds |
 | Warning threshold | 80% | 50–95% |

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "harshith.system-monitor",
   "name": "System Monitor",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "Harshith",
   "license": "MIT",
   "homepage": "https://github.com/Harshith292002/omarchy-system-monitor",
@@ -28,7 +28,7 @@
       "networkInterface": ""
     },
     "schema": [
-      { "key": "barMode", "type": "enum", "label": "Bar display", "options": ["Adaptive", "CPU", "Memory", "GPU", "Both"], "defaultValue": "Adaptive" },
+      { "key": "barMode", "type": "enum", "label": "Bar display", "options": ["Adaptive", "CPU", "Memory", "GPU", "Both", "Icon"], "defaultValue": "Adaptive" },
       { "key": "closedRefreshSec", "type": "integer", "label": "Closed refresh interval (seconds)", "min": 2, "max": 60, "step": 1, "defaultValue": 5 },
       { "key": "openRefreshSec", "type": "integer", "label": "Open refresh interval (seconds)", "min": 1, "max": 10, "step": 1, "defaultValue": 2 },
       { "key": "warningPercent", "type": "integer", "label": "Warning threshold", "min": 50, "max": 95, "step": 1, "defaultValue": 80 },

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -117,13 +117,14 @@ test("manifest describes a public bar widget with configurable thresholds", () =
   const manifest = JSON.parse(fs.readFileSync(path.join(root, "manifest.json"), "utf8"))
   assert.equal(manifest.schemaVersion, 1)
   assert.equal(manifest.id, "harshith.system-monitor")
-  assert.equal(manifest.version, "1.1.1")
+  assert.equal(manifest.version, "1.2.0")
   assert.equal(manifest.license, "MIT")
   assert.equal(manifest.homepage, "https://github.com/Harshith292002/omarchy-system-monitor")
   assert.equal(manifest.barWidget.defaultSection, "right")
   assert.ok(manifest.barWidget.schema.some((entry) => entry.key === "warningPercent"))
   const barMode = manifest.barWidget.schema.find((entry) => entry.key === "barMode")
   assert.ok(barMode.options.includes("GPU"))
+  assert.ok(barMode.options.includes("Icon"))
 })
 
 test("panel exposes bar cycling, btop launch, and live hostname title", () => {


### PR DESCRIPTION
Adds `Icon` to `barMode`: the plugin glyph alone in the bar, no live text, for people who want the dashboard without the numbers. It still tints at warning/critical pressure, keeps the tooltip, and right-click cycling includes it. Implemented as a `BarIconButton` beside the existing `WidgetButton` with a shared press handler; the panel anchors to whichever is visible.

Tests updated (version + option), `omarchy plugin validate` passes, discovery fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TbDx2DdRCVv9AdwqiMzDV