### PR TITLE
Auto-discover every local disk in the capacity section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.0 - 2026-08-31
+
+- List every mounted local disk in the capacity section automatically, one row
+  per physical device, alongside the existing root and swap meters. Pseudo and
+  network filesystems (tmpfs, overlay, squashfs, NFS, and the like) are left
+  out, and subvolumes or bind mounts on one device collapse to a single row.
+  No configuration.
+
 ## 1.1.1 - 2026-08-26
 
 - Fix GPU temperature discovery on the `xe` driver (Intel Arc, Meteor Lake,

--- a/Metrics.js
+++ b/Metrics.js
@@ -181,18 +181,58 @@ function parseByteCount(raw) {
   return isFinite(value) && value >= 0 ? value : -1
 }
 
-function parseFilesystem(raw) {
+// On-disk filesystem types worth a capacity row. An allowlist keeps the ever-
+// growing set of pseudo filesystems (tmpfs, overlay, squashfs, cgroup, and so
+// on) out without having to name each one; `df -l` already drops network
+// mounts before this runs.
+var CAPACITY_FILESYSTEMS = {
+  ext2: true, ext3: true, ext4: true, btrfs: true, xfs: true, f2fs: true,
+  zfs: true, jfs: true, reiserfs: true, nilfs2: true, bcachefs: true,
+  vfat: true, exfat: true, ntfs: true, ntfs3: true, hfsplus: true, ufs: true
+}
+
+// Parses `df -P -k -l -T` (POSIX columns, 1K blocks, local only, type column):
+//   Filesystem  Type  1024-blocks  Used  Available  Capacity  Mounted on
+// Returns one entry per physical device, in df's order, as
+// { mount, total, used, percent } with bytes and percent -1 when size is 0.
+// The root filesystem is always included so its meter cannot break; every
+// other row must be a real on-disk type. Rows sharing a source device (btrfs
+// subvolumes, bind mounts) collapse to the shortest mount path, since they
+// report the same free space anyway.
+function parseFilesystems(raw) {
   var lines = String(raw || "").trim().split("\n")
-  if (lines.length < 2) return null
-  var fields = lines[lines.length - 1].trim().split(/\s+/)
-  if (fields.length < 6) return null
-  var total = finiteNumber(fields[1], 0) * 1024
-  var used = finiteNumber(fields[2], 0) * 1024
-  return {
-    total: total,
-    used: used,
-    percent: total > 0 ? clamp(used * 100 / total, 0, 100) : -1
+  var byDevice = ({})
+  var order = []
+
+  for (var i = 1; i < lines.length; i++) {
+    var fields = lines[i].trim().split(/\s+/)
+    if (fields.length < 7) continue
+    var device = fields[0]
+    var type = fields[1]
+    var mount = fields.slice(6).join(" ")
+    if (mount !== "/" && !CAPACITY_FILESYSTEMS[type]) continue
+
+    var total = finiteNumber(fields[2], 0) * 1024
+    var used = finiteNumber(fields[3], 0) * 1024
+    var entry = {
+      mount: mount,
+      total: total,
+      used: used,
+      percent: total > 0 ? clamp(used * 100 / total, 0, 100) : -1
+    }
+
+    var seen = byDevice[device]
+    if (!seen) {
+      byDevice[device] = entry
+      order.push(device)
+    } else if (mount.length < seen.mount.length) {
+      byDevice[device] = entry
+    }
   }
+
+  var result = []
+  for (var d = 0; d < order.length; d++) result.push(byDevice[order[d]])
+  return result
 }
 
 // Rolling-window peak, used to pin a sparkline's vertical scale so the chart
@@ -229,7 +269,7 @@ if (typeof module !== "undefined" && module.exports) {
     parseDiscovery: parseDiscovery,
     parseGpuPercent: parseGpuPercent,
     parseByteCount: parseByteCount,
-    parseFilesystem: parseFilesystem,
+    parseFilesystems: parseFilesystems,
     peakValue: peakValue,
     maximumPercent: maximumPercent,
     escapeMarkup: escapeMarkup

--- a/Metrics.qml
+++ b/Metrics.qml
@@ -39,6 +39,7 @@ Item {
   property real filesystemPercent: -1
   property double filesystemUsed: 0
   property double filesystemTotal: 0
+  property var extraFilesystems: []
   property string hostname: ""
   property string autoInterface: ""
   property string cpuTempPath: ""
@@ -341,15 +342,25 @@ Item {
 
   Process {
     id: filesystemProc
-    command: ["df", "-Pk", "/"]
+    // Local, on-disk filesystems only, with a type column; the parser drops
+    // pseudo mounts and collapses subvolumes. `-l` keeps a stale network
+    // mount from hanging df.
+    command: ["df", "-P", "-k", "-l", "-T"]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        var parsed = Model.parseFilesystem(text)
-        if (!parsed) return
-        root.filesystemPercent = parsed.percent
-        root.filesystemUsed = parsed.used
-        root.filesystemTotal = parsed.total
+        var all = Model.parseFilesystems(text)
+        var extras = []
+        for (var i = 0; i < all.length; i++) {
+          if (all[i].mount === "/") {
+            root.filesystemPercent = all[i].percent
+            root.filesystemUsed = all[i].used
+            root.filesystemTotal = all[i].total
+          } else {
+            extras.push(all[i])
+          }
+        }
+        root.extraFilesystems = extras
       }
     }
   }

--- a/Panel.qml
+++ b/Panel.qml
@@ -191,6 +191,25 @@ Panel {
     return "DISK · " + shortDiskName(devices[0]) + " +" + (devices.length - 1)
   }
 
+  function mountBasename(mount) {
+    var segments = String(mount).split("/")
+    return segments[segments.length - 1] || String(mount)
+  }
+
+  // Auto-discovered mount paths. Escaped like the interface name above for the
+  // shared bar tooltip. Normally the last path segment (/mnt/data -> "data");
+  // when two disks share a basename the colliding ones show the full path.
+  function mountLabel(mount) {
+    var target = String(mount)
+    var base = mountBasename(target)
+    var mounts = metrics.extraFilesystems
+    for (var i = 0; i < mounts.length; i++) {
+      var other = String(mounts[i].mount)
+      if (other !== target && mountBasename(other) === base) return Model.escapeMarkup(target)
+    }
+    return Model.escapeMarkup(base)
+  }
+
   function levelColor(value, warn, crit) {
     if (!isFinite(value) || value < 0) return root.muted
     if (value >= crit) return root.urgent
@@ -339,7 +358,11 @@ Panel {
     open: root.opened
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(380))
-    contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(600))
+    // Capped height, not a fixed one: fittedContentHeight still shrinks to fit
+    // the screen and to the content itself, this just raises the ceiling so
+    // the added CapacityRow entries (one per auto-discovered disk) aren't
+    // clipped.
+    contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(600 + metrics.extraFilesystems.length * 40))
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -691,6 +714,17 @@ Panel {
               label: "Swap"
               value: root.formatPair(metrics.swapUsed, metrics.swapTotal)
               percentValue: metrics.swapPercent
+            }
+
+            Repeater {
+              model: metrics.extraFilesystems
+
+              CapacityRow {
+                required property var modelData
+                label: root.mountLabel(modelData.mount)
+                value: root.formatPair(modelData.used, modelData.total)
+                percentValue: modelData.percent
+              }
             }
           }
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ background daemon or telemetry service.
 - Two-minute CPU, memory, and GPU history with per-core utilization
 - Mirrored network throughput history on a shared scale
 - Automatic disk discovery with live read and write rates
-- Root filesystem and swap capacity meters
+- Root, swap, and every mounted local disk in one capacity section, discovered automatically
 - Configurable refresh intervals and warning thresholds
 - Native Omarchy styling with no bundled theme or hard-coded palette
 
@@ -66,11 +66,17 @@ pressure. Warning and critical colors follow the active Omarchy theme.
 | Disk throughput | `/proc/diskstats` and `/sys/class/block` |
 | CPU temperature | `/sys/class/hwmon` (`coretemp`, `k10temp`, or `zenpower`) |
 | GPU load, temperature, and VRAM | `/sys/class/drm/card*/device` (`gpu_busy_percent`, `hwmon`, `mem_info_vram_*`) |
-| Root capacity | `df` |
+| Filesystem capacity | `df -P -k -l -T` |
 
 Temperature is shown when a supported package sensor is available. Disk
 activity aggregates physical devices and ignores loop, RAM, zram, floppy, and
 optical devices.
+
+The capacity section lists the root filesystem, swap, and every other local
+disk `df` reports. Pseudo filesystems (tmpfs, overlay, squashfs, and so on)
+and network mounts are excluded by an on-disk-type allowlist, and subvolumes
+or bind mounts on one device are shown once. Removable drives appear and
+disappear as they are mounted. Nothing to configure.
 
 Each GPU tile is gated on its own sensor, because vendors expose different
 subsets:

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "harshith.system-monitor",
   "name": "System Monitor",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "Harshith",
   "license": "MIT",
   "homepage": "https://github.com/Harshith292002/omarchy-system-monitor",

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -113,11 +113,75 @@ test("byte counter parser distinguishes zero from unavailable", () => {
   assert.equal(Model.parseByteCount("nope"), -1)
 })
 
+test("filesystem discovery lists real local disks and skips pseudo mounts", () => {
+  const raw = [
+    "Filesystem     Type   1024-blocks      Used  Available Capacity Mounted on",
+    "/dev/nvme0n1p2 ext4     491252516 200000000  266000000      43% /",
+    "/dev/nvme0n1p1 vfat        523248     55000     468248      11% /boot",
+    "tmpfs          tmpfs      8143972       120    8143852       1% /run",
+    "/dev/sda1      xfs     1952559104 500000000 1452559104      26% /mnt/data",
+    "efivarfs       efivarfs       128        50         74      41% /sys/firmware/efi/efivars"
+  ].join("\n")
+  const result = Model.parseFilesystems(raw)
+  assert.deepEqual(result.map((entry) => entry.mount), ["/", "/boot", "/mnt/data"])
+  assert.equal(result[0].total, 491252516 * 1024)
+  assert.equal(result[0].used, 200000000 * 1024)
+  assert.ok(result[0].percent > 40 && result[0].percent < 42)
+  assert.ok(!("device" in result[0]))
+})
+
+test("filesystem discovery collapses subvolumes on one device to a single row", () => {
+  const raw = [
+    "Filesystem Type  1024-blocks      Used Available Capacity Mounted on",
+    "/dev/sda2  btrfs   976302080 400000000 574000000      42% /",
+    "/dev/sda2  btrfs   976302080 400000000 574000000      42% /home",
+    "/dev/sda2  btrfs   976302080 400000000 574000000      42% /.snapshots",
+    "/dev/sdb1  ext4    488384000 100000000 363000000      22% /mnt/backup"
+  ].join("\n")
+  const result = Model.parseFilesystems(raw)
+  assert.deepEqual(result.map((entry) => entry.mount), ["/", "/mnt/backup"])
+})
+
+test("filesystem discovery always keeps the root entry even with an unlisted type", () => {
+  const raw = [
+    "Filesystem Type    1024-blocks     Used Available Capacity Mounted on",
+    "overlay    overlay   61202244 20000000  41202244      33% /",
+    "tmpfs      tmpfs      8143972      100   8143872       1% /tmp"
+  ].join("\n")
+  const result = Model.parseFilesystems(raw)
+  assert.deepEqual(result.map((entry) => entry.mount), ["/"])
+  assert.equal(result[0].total, 61202244 * 1024)
+})
+
+test("filesystem discovery marks a zero-block filesystem unavailable", () => {
+  const raw = [
+    "Filesystem Type 1024-blocks Used Available Capacity Mounted on",
+    "/dev/sdz1  ext4           0    0         0        - /mnt/pending"
+  ].join("\n")
+  const result = Model.parseFilesystems(raw)
+  assert.equal(result.length, 1)
+  assert.equal(result[0].total, 0)
+  assert.equal(result[0].percent, -1)
+})
+
+test("filesystem discovery tolerates empty df output", () => {
+  assert.deepEqual(Model.parseFilesystems(""), [])
+  assert.deepEqual(
+    Model.parseFilesystems("Filesystem Type 1024-blocks Used Available Capacity Mounted on"),
+    []
+  )
+})
+
+test("auto-discovered mount labels are escaped before display", () => {
+  const qml = fs.readFileSync(path.join(root, "Panel.qml"), "utf8")
+  assert.match(qml, /function mountLabel\(mount\)\s*{[\s\S]*?Model\.escapeMarkup\(/)
+})
+
 test("manifest describes a public bar widget with configurable thresholds", () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(root, "manifest.json"), "utf8"))
   assert.equal(manifest.schemaVersion, 1)
   assert.equal(manifest.id, "harshith.system-monitor")
-  assert.equal(manifest.version, "1.1.1")
+  assert.equal(manifest.version, "1.2.0")
   assert.equal(manifest.license, "MIT")
   assert.equal(manifest.homepage, "https://github.com/Harshith292002/omarchy-system-monitor")
   assert.equal(manifest.barWidget.defaultSection, "right")


### PR DESCRIPTION
The CAPACITY section currently shows only the root filesystem and swap. This adds a row for every other mounted local disk, discovered automatically — no new setting.

## How

- `parseFilesystems(raw)` parses `df -P -k -l -T` and returns `{ mount, total, used, percent }` per source device, in df order.
- A filesystem-type allowlist (`ext2/3/4`, `btrfs`, `xfs`, `f2fs`, `zfs`, `vfat`, `exfat`, `ntfs`/`ntfs3`, `bcachefs`, and a few more) keeps pseudo mounts out without enumerating them. `/` is always included so the root meter can't break.
- `-l` limits df to local filesystems, so a stale NFS/CIFS mount can't hang the poll; network shares are out of scope for "disks".
- Rows on the same device (btrfs subvolumes, bind mounts) collapse to the shortest mount path — they share free space, so one row is honest.
- `Metrics.qml` sends the `/` entry to the existing root meter and the rest to a `Repeater` of `CapacityRow`. Labels are the mount basename, escaped via `Model.escapeMarkup` like the interface name; colliding basenames fall back to the full path.
- Poll cadence unchanged: panel-open only, 60s throttle.

## Points to decide

- Version bump + CHANGELOG are included, matching how 1.1.1 landed — happy to drop if you'd rather own that.
- btrfs subvolume collapse: `/` and `/home` on one btrfs device show as a single row (the root meter). If you'd prefer one row per mountpoint, it's a one-line change to the dedupe key.
- Allowlist contents — additions welcome.
- `docs/screenshots/system-monitor-panel.png` predates this; can attach a refreshed capture with extra drives if you want it in the PR.

## Tests

`node --test tests/model.test.js` (18 pass), `jq empty manifest.json`, `omarchy plugin validate .`, `bash tests/discovery.test.sh` — all green. Verified live in a running shell.
